### PR TITLE
Bug Fixes & Performance Enhancements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,40 @@
+{
+    "parser": "@typescript-eslint/parser",
+    "plugins": ["@typescript-eslint"],
+    "extends": [
+      "eslint:recommended",
+      "plugin:@typescript-eslint/recommended",
+      "prettier"
+    ],
+    "env": {
+      "es6": true,
+      "browser": true,
+      "jest": true,
+      "node": true
+    },
+    "rules": {
+      "@typescript-eslint/explicit-module-boundary-types": 0,
+      "@typescript-eslint/ban-ts-comment": 0,
+      "@typescript-eslint/explicit-function-return-type": 0,
+      "@typescript-eslint/explicit-member-accessibility": 0,
+      "@typescript-eslint/indent": 0,
+      "@typescript-eslint/member-delimiter-style": 0,
+      "@typescript-eslint/no-empty-function": 0,
+      "@typescript-eslint/no-explicit-any": 0,
+      "@typescript-eslint/no-var-requires": 0,
+      "@typescript-eslint/no-use-before-define": 0,
+      "@typescript-eslint/no-unused-vars": [
+        2,
+        {
+          "argsIgnorePattern": "^_"
+        }
+      ]
+      // "no-console": [
+      //   0,
+      //   {
+      //     "allow": ["warn", "error"]
+      //   }
+      // ]
+    }
+  }
+  

--- a/README.md
+++ b/README.md
@@ -14,17 +14,18 @@ To run the liquidator you will need:
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
 | `CLUSTER` | `mainnet` | The Solana cluster to use |
-| `ENDPOINT_URL` | `https://solana-api.projectserum.com` | Your RPC node endpoint |
+| `ENDPOINT_URL` | `https://mango.rpcpool.com/946ef7337da3f5b8d3e4a34e7f88` | Your RPC node endpoint |
 | `KEYPAIR` | `${HOME}/.config/solana/id.json` | The location of your wallet keypair |
 | `GROUP` | `mainnet.1` | Name of the group in ids.json to run the Liquidator against |
 | `TARGETS` | `0 0 0 0 0 0 0 0` | Space separated list of the amount of each asset to maintain when rebalancing |
 | `INTERVAL` | `3500` | Milliseconds to wait before checking for sick accounts |
-| `INTERVAL_ACCOUNTS` | `120000` | Milliseconds to wait before reloading all Mango accounts |
+| `INTERVAL_ACCOUNTS` | `600000` | Milliseconds to wait before reloading all Mango accounts |
 | `INTERVAL_WEBSOCKET` | `300000` | Milliseconds to wait before reconnecting to the websocket |
-| `LIQOR_PK` | N/A | Liqor Mango account Public Key, by default uses the largest value account owned by the keypair |
+| `LIQOR_PK` | N/A | Liqor Mango Account Public Key, by default uses the largest value account owned by the keypair |
 | `WEBHOOK_URL` | N/A | Discord webhook URL to post liquidation events and errors to |
+| `LIAB_LIMIT` | `0.9` | Percentage of your available margin to use when taking on liabs |
 
-You can add these varibles to a `.env` file in the project root to load automatically on liquidator startup. For example:
+You can add these variables to a `.env` file in the project root to load automatically on liquidator startup. For example:
 ```bash
 ENDPOINT_URL=https://solana-api.projectserum.com
 KEYPAIR=${HOME}/.config/solana/my-keypair.json 
@@ -32,6 +33,9 @@ TARGETS=500 0.1 0.75 0 0 0 0 0
 ```
 ## Rebalancing
 The liquidator will attempt to close all perp positions, and balance the tokens in the liqor account after each liquidation. By default it will sell all token assets into USDC. You can choose to maintain a certain amount of each asset through this process by editing the value in the `TARGETS` environment variable at the position of the asset. You can find the order of the assets in the 'oracles' property of the group in [ids.json](https://github.com/blockworks-foundation/mango-client-v3/blob/main/src/ids.json#L81) The program will attempt to make buy/sell orders during balancing to maintain this level.
+
+## Advanced Orders Triggering
+The liquidator triggers advanced orders for users when their trigger condition is met. Upon successfully triggering the order, the liquidator wallet will receive 100x the transaction fee as a reward.
 
 ## Run
 ```

--- a/src/liquidator.ts
+++ b/src/liquidator.ts
@@ -34,7 +34,7 @@ envExpand(Env.config());
 
 const interval = parseInt(process.env.INTERVAL || '3500');
 const refreshAccountsInterval = parseInt(
-  process.env.INTERVAL_ACCOUNTS || '120000',
+  process.env.INTERVAL_ACCOUNTS || '600000',
 );
 const refreshWebsocketInterval = parseInt(
   process.env.INTERVAL_WEBSOCKET || '300000',

--- a/src/liquidator.ts
+++ b/src/liquidator.ts
@@ -645,7 +645,7 @@ async function liquidateSpot(
         }`,
       );
 
-      if (maxNet.lt(ONE_I80F48) || maxNetIndex == -1) {
+      if (maxNet.lt(ZERO_I80F48) || maxNetIndex == -1) {
         const highestHealthMarket = perpMarkets
           .map((perpMarket, i) => {
             const marketIndex = mangoGroup.getPerpMarketIndex(

--- a/src/liquidator.ts
+++ b/src/liquidator.ts
@@ -383,11 +383,14 @@ async function refreshAccounts(
   try {
     console.log('Refreshing accounts...');
     console.time('getAllMangoAccounts');
-    mangoAccounts.splice(0, mangoAccounts.length, ...(await client.getAllMangoAccounts(
-      mangoGroup,
-      undefined,
-      true,
-    )));
+
+    mangoAccounts.splice(
+      0,
+      mangoAccounts.length,
+      ...(await client.getAllMangoAccounts(mangoGroup, undefined, true)),
+    );
+    shuffleArray(mangoAccounts);
+
     console.timeEnd('getAllMangoAccounts');
     console.log(`Fetched ${mangoAccounts.length} accounts`);
   } catch (err) {
@@ -1163,6 +1166,13 @@ async function closePositions(
     }
   } catch (err) {
     console.error('Error closing positions', err);
+  }
+}
+
+function shuffleArray(array) {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
   }
 }
 

--- a/src/liquidator.ts
+++ b/src/liquidator.ts
@@ -1100,6 +1100,10 @@ async function closePositions(
             side == 'sell'
               ? price.mul(ONE_I80F48.sub(liquidationFee)).toNumber()
               : price.mul(ONE_I80F48.add(liquidationFee)).toNumber();
+          const bookSideInfo =
+            side == 'sell'
+              ? await connection.getAccountInfo(perpMarket.bids)
+              : await connection.getAccountInfo(perpMarket.asks);
 
           console.log(
             `${side}ing ${basePositionSize} of ${groupIds?.perpMarkets[index].baseSymbol}-PERP for $${orderPrice}`,
@@ -1115,8 +1119,8 @@ async function closePositions(
             orderPrice,
             basePositionSize,
             'ioc',
-            undefined,
-            undefined,
+            0,
+            bookSideInfo ? bookSideInfo : undefined,
             true,
           );
         }

--- a/src/liquidator.ts
+++ b/src/liquidator.ts
@@ -304,7 +304,7 @@ function watchAccounts(
 
     mangoSubscriptionId = connection.onProgramAccountChange(
       mangoProgramId,
-      ({ accountId, accountInfo }) => {
+      async ({ accountId, accountInfo }) => {
         const index = mangoAccounts.findIndex((account) =>
           account.publicKey.equals(accountId),
         );
@@ -320,6 +320,7 @@ function watchAccounts(
             mangoAccounts[index].spotOpenOrdersAccounts;
           mangoAccount.spotOpenOrdersAccounts = spotOpenOrdersAccounts;
           mangoAccounts[index] = mangoAccount;
+          await mangoAccount.loadOpenOrders(connection, mangoGroup.dexProgramId)
         }
       },
       'processed',

--- a/src/liquidator.ts
+++ b/src/liquidator.ts
@@ -480,14 +480,14 @@ async function liquidateAccount(
     throw new Error('Account no longer liquidatable');
   }
 
-  while (liqee.hasAnySpotOrders()) {
+  for (let r = 0; r < 5 && liqee.hasAnySpotOrders(); r++) {
     for (let i = 0; i < mangoGroup.spotMarkets.length; i++) {
-      const spotMarket = spotMarkets[i];
-      const baseRootBank = rootBanks[i];
-      const quoteRootBank = rootBanks[QUOTE_INDEX];
+      if (liqee.inMarginBasket[i]) {
+        const spotMarket = spotMarkets[i];
+        const baseRootBank = rootBanks[i];
+        const quoteRootBank = rootBanks[QUOTE_INDEX];
 
-      if (baseRootBank && quoteRootBank) {
-        if (liqee.inMarginBasket[i]) {
+        if (baseRootBank && quoteRootBank) {
           console.log('forceCancelOrders ', i);
           await client.forceCancelSpotOrders(
             mangoGroup,

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,8 +31,8 @@
     regenerator-runtime "^0.13.4"
 
 "@blockworks-foundation/mango-client@git+https://github.com/blockworks-foundation/mango-client-v3.git":
-  version "3.2.9"
-  resolved "git+https://github.com/blockworks-foundation/mango-client-v3.git#a24f41584cff5a7548e3f9aafb3357036c55317c"
+  version "3.2.14"
+  resolved "git+https://github.com/blockworks-foundation/mango-client-v3.git#7fb0f294a6c7cec98348cefbbfc3a725bc10c232"
   dependencies:
     "@project-serum/anchor" "^0.16.2"
     "@project-serum/serum" "0.13.55"


### PR DESCRIPTION
* Increase default refreshAccounts interval
* Add interval between rebalancing attempts
* Add liability limit
* Improve logging and error handling
* Run crank with place perp order instruction
* Reload open orders when mango account changes
* Shuffle mango accounts on load
* Remove unnecessary sleep calls
* Add max retries to forceCancelSpotOrders
* Fix shouldLiquidateSpot logic
* Base order prices on liq fee
* Upgrade client
* Update README