### PR TITLE
Optional commitment level

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ This mode never triggers advanced orders.
 | `LIAB_LIMIT` | `0.9` | Percentage of your available margin to use when taking on liabilities |
 | `MIN_EQUITY` | `0` | Minimum account equity required to liquidate |
 | `LIQUIDATABLE_FEED_WEBSOCKET_ADDRESS` | N/A | Websocket URL of the liquidatable-accounts-feed service, see above |
+| `COMMITMENT_LEVEL` | `processed` | Commitment level for the connection |
 
 You can add these variables to a `.env` file in the project root to load automatically on liquidator startup. For example:
 ```bash

--- a/src/liquidator.ts
+++ b/src/liquidator.ts
@@ -57,6 +57,11 @@ const cluster = (process.env.CLUSTER || 'mainnet') as Cluster;
 const groupName = process.env.GROUP || 'mainnet.1';
 const groupIds = config.getGroup(cluster, groupName) ?? (() => { throw new Error(`Group ${groupName} not found`); })();
 
+
+// The Triton team recommends using the commitment level `confirmed` in order
+// to avoid BlockhashNotFound errors. Adding a parameter.
+const commitmentLevel = process.env.COMMITMENT_LEVEL || 'processed'
+
 // Target values to keep in spot, ordered the same as in mango client's ids.json
 // Example:
 //
@@ -85,9 +90,11 @@ const payer = new Account(
       ),
   ),
 );
+
+console.log(`Commitment level: ${commitmentLevel}`);
 console.log(`Payer: ${payer.publicKey.toBase58()}`);
 const rpcEndpoint = process.env.ENDPOINT_URL || config.cluster_urls[cluster];
-const connection = new Connection(rpcEndpoint, 'processed' as Commitment);
+const connection = new Connection(rpcEndpoint, commitmentLevel as Commitment);
 const client = new MangoClient(connection, mangoProgramId);
 
 let mangoSubscriptionId = -1;


### PR DESCRIPTION
The Triton team recommends using the commitment level `confirmed` in order to avoid BlockhashNotFound errors. Adding a parameter.