### PR TITLE
Restore balanceAccount functionality

### DIFF
--- a/src/liquidator.ts
+++ b/src/liquidator.ts
@@ -1063,7 +1063,6 @@ async function balanceAccount(
   spotMarkets: Market[],
   perpMarkets: PerpMarket[],
 ) {
-  return;
   if (Date.now() < lastRebalance + rebalanceInterval) {
     return;
   }


### PR DESCRIPTION
The `return` introduced in c76d4f92584eb9c2c435f5771213fe0ea465d5a8 breaks `balanceAccount`'s functionality. This just removes that line.